### PR TITLE
Add Firewall Rules for Both Wireless and Ethernet

### DIFF
--- a/pia-tools
+++ b/pia-tools
@@ -39,8 +39,11 @@ if [[ -z "$PIA_OPEN_PORT_FILE" ]]; then
     PIA_OPEN_PORT_FILE="$PIA_CONFIG_DIR/open_port"
 fi
 PIA_OPEN_PORT="$(cat $PIA_OPEN_PORT_FILE 2>/dev/null)"
-if [[ -z "$NET_DEV" ]]; then
-    NET_DEV='enp104s0'
+if [[ -z "$NET_DEV_ETHERNET" ]]; then
+    NET_DEV_ETHERNET=$(ifconfig | awk -F ":" '/^e/ {print $1}') || NET_DEV_ETHERNET='enp2s0'
+fi
+if [[ -z "$NET_DEV_WIFI" ]]; then
+    NET_DEV_WIFI=$(ifconfig | awk -F ":" '/^wl/ {print $1}') || NET_DEV_WIFI='wlp3s0'
 fi
 if [[ -z "$VIRT_NET_DEV" ]]; then
     VIRT_NET_DEV='tun0'
@@ -138,15 +141,19 @@ ufw_update() {
 
 ufw_allow_non_vpn() {
     echo -n 'Allowing non-VPN traffic ... '
-    ufw delete deny out on $NET_DEV > /dev/null 2>&1
-    ufw delete deny in on $NET_DEV > /dev/null 2>&1
+    ufw delete deny out on $NET_DEV_WIFI > /dev/null 2>&1
+    ufw delete deny out on $NET_DEV_ETHERNET > /dev/null 2>&1
+    ufw delete deny in on $NET_DEV_WIFI > /dev/null 2>&1
+    ufw delete deny in on $NET_DEV_ETHERNET > /dev/null 2>&1
     echo 'Done!'
 }
 
 ufw_deny_non_vpn() {
     echo -n 'Denying non-VPN traffic ... '
-    ufw deny out on $NET_DEV > /dev/null 2>&1
-    ufw deny in on $NET_DEV > /dev/null 2>&1
+    ufw deny out on $NET_DEV_WIFI > /dev/null 2>&1
+    ufw deny out on $NET_DEV_ETHERNET > /dev/null 2>&1
+    ufw deny in on $NET_DEV_WIFI > /dev/null 2>&1
+    ufw deny in on $NET_DEV_ETHERNET > /dev/null 2>&1
     echo 'Done!'
 }
 

--- a/pia-tools.groff
+++ b/pia-tools.groff
@@ -86,6 +86,10 @@ Path to transmission config (default: /home/dl/.config/transmission-daemon/setti
 Path to the file where the currently open (forwarded) port is stored (default: $PIA_CONFIG_DIR/open_port)
 .IP \fBVIRT_NET_DEV\fR
 The virtual network device used by OpenVPN (device: tun0)
+.IP \fBNET_DEV_ETHERNET\fR
+The ethernet device used when adding and removing firewall rules with -a and -d. If not set, pia-tools will try to detect the device name. (e.g.: eth0, fallback: enp2s0)
+.IP \fBNET_DEV_WIFI\fR
+The wireless device used when adding and removing firewall rules with -a and -d. If not set, pia-tools will try to detect the device name. (e.g.: wlan0, fallback: wlp3s0)
 .SH FILES
 /etc/pia-tools.conf
 /etc/openvpn/pia/


### PR DESCRIPTION
This is meant to adress #7 and replaces `NET_DEV` with `NET_DEV_ETHERNET` and `NET_DEV_WIFI` and adds/deletes firewall rules for both of them. I figure its best to do both instead of just the active one in case of switching (if I unplugged my ethernet cable, it would automatically switch to wifi and vice versa). I also added them to the man page.
