### PR TITLE
Single user VPN

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -15,7 +15,7 @@ source=('https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-up'
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-down'
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-route-up'
-        ''https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-tools.install')
+        'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-tools.install')
 install="${pkgname}.install"
 
 package() {

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -33,6 +33,6 @@ package() {
     install -Dm644 pia@.service "${pkgdir}/usr/lib/systemd/system/pia@.service"
     install -Dm644 pia_common "${pkgdir}/etc/openvpn/pia/pia_common"
     install -Dm755 pia-up "${pkgdir}/etc/openvpn/pia/pia-up"
-    install -Dm755 pia-up "${pkgdir}/etc/openvpn/pia/pia-down"
-    install -Dm755 pia-up "${pkgdir}/etc/openvpn/pia/pia-route-up"
+    install -Dm755 pia-down "${pkgdir}/etc/openvpn/pia/pia-down"
+    install -Dm755 pia-route-up "${pkgdir}/etc/openvpn/pia/pia-route-up"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -8,20 +8,14 @@ arch=('any')
 url='https://github.com/pschmitt/pia-tools'
 license=('GPL3')
 depends=('transmission-cli' 'dnsutils' 'openvpn' 'systemd' 'sudo' 'wget' 'ufw' 'unzip' 'sed')
-source=('https://raw.github.com/pschmitt/pia-tools/master/pia-tools'
-        'https://raw.github.com/pschmitt/pia-tools/master/pia-tools.groff'
-        'https://raw.github.com/pschmitt/pia-tools/master/pia@.service'
-        'https://raw.github.com/pschmitt/pia-tools/master/pia_common'
-        'https://raw.github.com/pschmitt/pia-tools/master/pia-up'
-        'https://raw.github.com/pschmitt/pia-tools/master/pia-down'
-        'https://raw.github.com/pschmitt/pia-tools/master/pia-tools.install')
-sha256sums=('ca54f20f6aaa60ae919a6e41c0b67a6d4a2f0f33c4fec04f827b9d5d77ea2643'
-            '22a34cb38e02ee1ed32e5697bc507df074629cbf5f1f7290a72e2c947cf611eb'
-            '118d961db36fb243e059543215a818d1546ec94e8d52b24c75b7de6fe64ba749'
-            'b571a8edbd9cb2a9ad63fadf360f64d4f80e291295f6c851b3a716c291ba3f8d'
-            '063ee23a9c98e728168affb8056cda201fb02ede2bd29dfe2b768ce834b35e7c'
-            '12299e53b5024084c73e604132db3a10b6e91763d90d484cabdd1985a17cf733'
-            'a7e82a1589406477898adee768d17c0270c8bcf341ae72be823095331c4e99c5')
+source=('https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-tools'
+        'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-tools.groff'
+        'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia@.service'
+        'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia_common'
+        'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-up'
+        'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-down'
+        'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-route-up'
+        ''https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-tools.install')
 install="${pkgname}.install"
 
 package() {
@@ -32,5 +26,5 @@ package() {
     install -Dm644 pia_common "${pkgdir}/etc/openvpn/pia/pia_common"
     install -Dm755 pia-up "${pkgdir}/etc/openvpn/pia/pia-up"
     install -Dm755 pia-up "${pkgdir}/etc/openvpn/pia/pia-down"
+    install -Dm755 pia-up "${pkgdir}/etc/openvpn/pia/pia-route-up"
 }
-

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -16,6 +16,14 @@ source=('https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-down'
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-route-up'
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-tools.install')
+md5sums=('23e2b79c6d4c1cc744595cd46ea345d0'
+         'b3fa2a6f12c6067bcb0024e54e25cf92'
+         'f74962b853215b88b54bad3dad9ba004'
+         '621f9228ba793b4307b354e92b8918c1'
+         'f25f00fe408f31e50d46d69a597c6ece'
+         'ac4fef9e231b1f7a9a009d7edf11db82'
+         '7077738433630cc80d758196b5bd2bde'
+         '24f69e9eea41a1247a974c7d5d3d9c30')
 install="${pkgname}.install"
 
 package() {

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ mkdir -p /etc/openvpn/pia
 cat <<EOM > /etc/openvpn/pia/pia_common
 auth-user-pass passwd
 script-security 2
-up "/usr/bin/pia-tools -g"
-down "/usr/bin/pia-tools --restore-dns"
+up "/etc/openvpn/pia/pia-up"
+down "/etc/openvpn/pia/pia-down"
 route-noexec
 route-up /etc/openvpn/pia/pia_route_up.sh
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ PIA_CLIENT_ID_FILE="$PIA_CONFIG_DIR/clientid"
 TRANSMISSION_SETTINGS_FILE='/home/dl/.config/transmission-daemon/settings.json'
 PIA_OPEN_PORT_FILE="$PIA_CONFIG_DIR/open_port"
 VIRT_NET_DEV='tun0'
+VPN_USER='transmission'
 ```
 
 ## Read more

--- a/README.md
+++ b/README.md
@@ -73,6 +73,25 @@ EOM
 # Start interactive setup
 pia-tools --setup
 ```
+If instead you wish to only route traffic for your torrent client:
+```bash
+mkdir -p /etc/openvpn/pia
+
+# Feel free to edit the up/down parameters
+cat <<EOM > /etc/openvpn/pia/pia_common
+auth-user-pass passwd
+script-security 2
+up "/usr/bin/pia-tools -g"
+down "/usr/bin/pia-tools --restore-dns"
+route-noexec
+route-up /etc/openvpn/pia/pia_route_up.sh
+log /var/log/openvpn-Netherlands
+
+EOM
+
+# Start interactive setup
+pia-tools --setup
+```
 
 The setup will store your credentials in `/etc/openvpn/pia/passwd`, download the config files from PIA and append `/etc/openvpn/pia/pia_common` to all of them.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ up "/usr/bin/pia-tools -g"
 down "/usr/bin/pia-tools --restore-dns"
 route-noexec
 route-up /etc/openvpn/pia/pia_route_up.sh
-log /var/log/openvpn-Netherlands
 
 EOM
 

--- a/pia-down
+++ b/pia-down
@@ -1,5 +1,14 @@
 #!/usr/bin/sh
 
+test "$PIA_CONF" || PIA_CONF='/etc/pia-tools.conf'
+[[ -r "$PIA_CONF" ]] && . $PIA_CONF
+
+if [[ -n "$VPN_USER" ]]; then
+  ip route flush table $VPNUSER
+  ip route flush cache
+fi
+
+
 # Restore DNS settings
 (sleep 5 && pia-tools --restore-dns --check)&
 # Update conky

--- a/pia-route-up
+++ b/pia-route-up
@@ -1,0 +1,24 @@
+#!/usr/bin/sh
+
+# Source config file
+test "$PIA_CONF" || PIA_CONF='/etc/pia-tools.conf'
+[[ -r "$PIA_CONF" ]] && . $PIA_CONF
+
+if [[ -n "$VPN_USER" ]]; then
+  ip route add "$trusted_ip"/32 via $route_net_gateway table $VPNUSER
+  ip route add 0.0.0.0/1 via $route_vpn_gateway table $VPNUSER
+  ip route add 128.0.0.0/1 via $route_vpn_gateway table $VPNUSER
+  ip route add "$route_network_1"/32 via $route_vpn_gateway table $VPNUSER
+  ip route add $ifconfig_remote dev $dev scope link src $ifconfig_local table $VPNUSER
+
+
+
+
+  if [[ `ip rule list | grep -c 0x3` == 0 ]]; then
+    ip rule add from all fwmark 0x3 lookup $VPNUSER
+  fi
+
+  ip route append default via 127.0.0.1 dev lo table $VPNUSER
+  ip route flush cache
+fi
+exit 0

--- a/pia-tools
+++ b/pia-tools
@@ -197,10 +197,18 @@ request_port() {
         echo "Client ID: $client_id"
         echo "VPN local IP: $local_vpn_ip"
     fi
+    if [[ -n "$VPN_USER" ]]; then
+        PIA_OPEN_PORT_NEW="$(\
+        sudo -u transmission \
+        curl -Ld "user=$username&pass=$passwd&client_id=$client_id&local_ip=$local_vpn_ip" \
+        https://www.privateinternetaccess.com/vpninfo/port_forward_assignment \
+        | grep -oE "[0-9]+" 2>&1)"
+    else
     PIA_OPEN_PORT_NEW="$(\
         curl -Ld "user=$username&pass=$passwd&client_id=$client_id&local_ip=$local_vpn_ip" \
         https://www.privateinternetaccess.com/vpninfo/port_forward_assignment \
         | grep -oE "[0-9]+" 2>&1)"
+    fi
     if test "$PIA_OPEN_PORT_NEW"; then
         echo "$PIA_OPEN_PORT_NEW" > "$PIA_OPEN_PORT_FILE"
         echo "Done! Port: $PIA_OPEN_PORT_NEW"
@@ -308,6 +316,27 @@ restore_dns() {
     fi
     mv -f /etc/resolv.conf.orig /etc/resolv.conf
 }
+rt_tables_add(){
+    if [ -z "`cat /etc/iproute2/rt_tables | grep '^51'`" ] ; then
+	    echo "51	$VPN_USER" >> /etc/iproute2/rt_tables
+	fi
+	    $echo "0" > /proc/sys/net/ipv4/conf/all/rp_filter 
+	    $echo "0" > /proc/sys/net/ipv4/conf/default/rp_filter 
+	    $echo "1" > /proc/sys/net/ipv4/ip_forward 
+	    $echo "1" > /proc/sys/net/ipv6/conf/default/forwarding
+	    $echo "1" > /proc/sys/net/ipv6/conf/all/forwarding
+}
+iptables_mark(){
+    iptables-save | grep -v "$VPNUSER VPN" | iptables-restore
+    iptables-save | grep -v "$dev" | iptables-restore
+    iptables -t mangle -A OUTPUT ! --dest $FULL_IP  -m owner --uid-owner $VPNUSER -j MARK --set-mark 0x3 -m comment --comment "$VPN_USER VPN"
+    # let $VPNUSER access lo and $INTERFACE
+    iptables -A OUTPUT -o lo -m owner --uid-owner $VPNUSER -j ACCEPT -m comment --comment "$VPN_USER VPN"
+    iptables -A OUTPUT -o $INTERFACE_VPN -m owner --uid-owner $VPNUSER -j ACCEPT -m comment --comment "$VPN_USER VPN"
+    # all packets on $INTERFACE_VPN needs to be masqueraded
+    iptables -t nat -A POSTROUTING -o $INTERFACE_VPN -j MASQUERADE -m comment --comment "$VPN_USER VPN"
+}
+
 
 # If no option -> refresh
 if [[ $# -eq 0 ]]; then
@@ -339,6 +368,11 @@ while true; do
         -d|--disallow)
             test "$action_fw" && exit 1
             action_fw=disallow
+            shift
+            ;;
+        -S|--SingleUser)
+            test -z "$VPN_USER" && exit 1
+            action_single_user=$VPN_USER
             shift
             ;;
         -p|--port)
@@ -416,7 +450,7 @@ test "$action_info" && { info; exit $?; }
 test "$action_setup" && { setup; exit $?; }
 test "$action_update" && update_config
 test "$action_check" && check_ovpn
-
+test "$action_single_user" && { rt_tables_add ; iptables_mark; exit $?; }
 case "$action_dns" in
     google) google_dns ;;
     restore) restore_dns ;;

--- a/pia-up
+++ b/pia-up
@@ -2,6 +2,8 @@
 
 # Change DNS settings right away
 pia-tools --pia-dns
+# Process single vpn user if $VPN_USER is defined
+pia-tools -S
 # Port forward request will fail if asked too early
 (sleep 5 && pia-tools -r)&
 # Update conky

--- a/pia_common
+++ b/pia_common
@@ -2,3 +2,5 @@ auth-user-pass passwd
 script-security 2 
 up "/etc/openvpn/pia/pia-up"
 down "/etc/openvpn/pia/pia-down"
+route-noexec
+route-up /etc/openvpn/pia/pia_route_up.sh

--- a/pia_common
+++ b/pia_common
@@ -2,5 +2,3 @@ auth-user-pass passwd
 script-security 2 
 up "/etc/openvpn/pia/pia-up"
 down "/etc/openvpn/pia/pia-down"
-route-noexec
-route-up /etc/openvpn/pia/pia_route_up.sh

--- a/pia_common_single_user
+++ b/pia_common_single_user
@@ -1,0 +1,6 @@
+auth-user-pass passwd
+script-security 2 
+up "/etc/openvpn/pia/pia-up"
+down "/etc/openvpn/pia/pia-down"
+route-noexec
+route-up /etc/openvpn/pia/pia_route_up.sh


### PR DESCRIPTION
I have added the option of tunneling only the traffic from a single user, with transmission being the obvious choice. I am sure this will require some revision, as there must be a cleaner way of doing this that would be clearly visible to a more experienced coder.

Adding VPN_USER=transmission to the conf file will enable this feature. pia_common must also be modified as indicated in the README for this to work properly. Perhaps an alternate pia_common file should be included.


This modification works by using a separate routing table and selective packet marking. 