### PR TITLE
Single user VPN

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -24,7 +24,7 @@ md5sums=('23e2b79c6d4c1cc744595cd46ea345d0'
          'f25f00fe408f31e50d46d69a597c6ece'
          '0ed5cf87b2853f9688c9df1dfe19b061'
          '7077738433630cc80d758196b5bd2bde'
-         'dda25e8221ef419c88992b5763fd35e0'
+         '4de2a7e4b4dfc5d7da8f0d490e957dd3'
          '24f69e9eea41a1247a974c7d5d3d9c30')
 
 install="${pkgname}.install"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -15,7 +15,7 @@ source=('https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-up'
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-down'
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-route-up'
-        ''https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-tools.install')
+        'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-tools.install')
 install="${pkgname}.install"
 
 package() {

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -24,7 +24,9 @@ md5sums=('23e2b79c6d4c1cc744595cd46ea345d0'
          'f25f00fe408f31e50d46d69a597c6ece'
          '0ed5cf87b2853f9688c9df1dfe19b061'
          '7077738433630cc80d758196b5bd2bde'
+         'dda25e8221ef419c88992b5763fd35e0'
          '24f69e9eea41a1247a974c7d5d3d9c30')
+
 install="${pkgname}.install"
 
 package() {

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -15,6 +15,7 @@ source=('https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-up'
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-down'
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-route-up'
+        'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia_common_single_user'
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-tools.install')
 md5sums=('23e2b79c6d4c1cc744595cd46ea345d0'
          'b3fa2a6f12c6067bcb0024e54e25cf92'

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=pia-tools
 pkgver=0.9.7.4
-pkgrel=5
+pkgrel=7
 pkgdesc='OpenVPN hook for privateinternetaccess.com'
 arch=('any')
 url='https://github.com/pschmitt/pia-tools'
@@ -17,14 +17,14 @@ source=('https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-route-up'
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia_common_single_user'
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-tools.install')
-md5sums=('28070f9b6b9378d884cf46fb5b76f665'
+md5sums=('7a49a36bbf4ef6d54596e681685d390a'
          'b3fa2a6f12c6067bcb0024e54e25cf92'
          'f74962b853215b88b54bad3dad9ba004'
          '621f9228ba793b4307b354e92b8918c1'
          'f25f00fe408f31e50d46d69a597c6ece'
          '0ed5cf87b2853f9688c9df1dfe19b061'
          '3aa6dffb97bfb02a719c56b53de5658a'
-         '3dfea239907a974507614357f6723856'
+         '80724ce4e66d14e2fef83edae778df0c'
          '24f69e9eea41a1247a974c7d5d3d9c30')
 install="${pkgname}.install"
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=pia-tools
 pkgver=0.9.7.4
-pkgrel=3
+pkgrel=4
 pkgdesc='OpenVPN hook for privateinternetaccess.com'
 arch=('any')
 url='https://github.com/pschmitt/pia-tools'
@@ -17,7 +17,7 @@ source=('https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-route-up'
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia_common_single_user'
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-tools.install')
-md5sums=('23e2b79c6d4c1cc744595cd46ea345d0'
+md5sums=('0edb36ca688af899b9bd5fc3f1bd8beb'
          'b3fa2a6f12c6067bcb0024e54e25cf92'
          'f74962b853215b88b54bad3dad9ba004'
          '621f9228ba793b4307b354e92b8918c1'

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -33,6 +33,6 @@ package() {
     install -Dm644 pia@.service "${pkgdir}/usr/lib/systemd/system/pia@.service"
     install -Dm644 pia_common "${pkgdir}/etc/openvpn/pia/pia_common"
     install -Dm755 pia-up "${pkgdir}/etc/openvpn/pia/pia-up"
-    install -Dm755 pia-up "${pkgdir}/etc/openvpn/pia/pia-down"
-    install -Dm755 pia-up "${pkgdir}/etc/openvpn/pia/pia-route-up"
+    install -Dm755 pia-down "${pkgdir}/etc/openvpn/pia/pia-down"
+    install -Dm755 pia-route-up "${pkgdir}/etc/openvpn/pia/pia-route-up"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -21,7 +21,7 @@ md5sums=('23e2b79c6d4c1cc744595cd46ea345d0'
          'f74962b853215b88b54bad3dad9ba004'
          '621f9228ba793b4307b354e92b8918c1'
          'f25f00fe408f31e50d46d69a597c6ece'
-         'ac4fef9e231b1f7a9a009d7edf11db82'
+         '0ed5cf87b2853f9688c9df1dfe19b061'
          '7077738433630cc80d758196b5bd2bde'
          '24f69e9eea41a1247a974c7d5d3d9c30')
 install="${pkgname}.install"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=pia-tools
 pkgver=0.9.7.4
-pkgrel=1
+pkgrel=2
 pkgdesc='OpenVPN hook for privateinternetaccess.com'
 arch=('any')
 url='https://github.com/pschmitt/pia-tools'

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=pia-tools
 pkgver=0.9.7.4
-pkgrel=2
+pkgrel=3
 pkgdesc='OpenVPN hook for privateinternetaccess.com'
 arch=('any')
 url='https://github.com/pschmitt/pia-tools'

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=pia-tools
 pkgver=0.9.7.4
-pkgrel=7
+pkgrel=9
 pkgdesc='OpenVPN hook for privateinternetaccess.com'
 arch=('any')
 url='https://github.com/pschmitt/pia-tools'
@@ -17,12 +17,12 @@ source=('https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-route-up'
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia_common_single_user'
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-tools.install')
-md5sums=('7a49a36bbf4ef6d54596e681685d390a'
+md5sums=('a31103ee9b3dc171c44ed957200c2675'
          'b3fa2a6f12c6067bcb0024e54e25cf92'
          'f74962b853215b88b54bad3dad9ba004'
          '621f9228ba793b4307b354e92b8918c1'
-         'f25f00fe408f31e50d46d69a597c6ece'
-         '0ed5cf87b2853f9688c9df1dfe19b061'
+         'cb9e0eb412089765d8a3083219f5c976'
+         '55a668ce83f4d252ed4808408c0b9390'
          '3aa6dffb97bfb02a719c56b53de5658a'
          '80724ce4e66d14e2fef83edae778df0c'
          '24f69e9eea41a1247a974c7d5d3d9c30')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -8,20 +8,14 @@ arch=('any')
 url='https://github.com/pschmitt/pia-tools'
 license=('GPL3')
 depends=('transmission-cli' 'dnsutils' 'openvpn' 'systemd' 'sudo' 'wget' 'ufw' 'unzip' 'sed')
-source=('https://raw.github.com/pschmitt/pia-tools/master/pia-tools'
-        'https://raw.github.com/pschmitt/pia-tools/master/pia-tools.groff'
-        'https://raw.github.com/pschmitt/pia-tools/master/pia@.service'
-        'https://raw.github.com/pschmitt/pia-tools/master/pia_common'
-        'https://raw.github.com/pschmitt/pia-tools/master/pia-up'
-        'https://raw.github.com/pschmitt/pia-tools/master/pia-down'
-        'https://raw.github.com/pschmitt/pia-tools/master/pia-tools.install')
-sha256sums=('ca54f20f6aaa60ae919a6e41c0b67a6d4a2f0f33c4fec04f827b9d5d77ea2643'
-            '22a34cb38e02ee1ed32e5697bc507df074629cbf5f1f7290a72e2c947cf611eb'
-            '118d961db36fb243e059543215a818d1546ec94e8d52b24c75b7de6fe64ba749'
-            'b571a8edbd9cb2a9ad63fadf360f64d4f80e291295f6c851b3a716c291ba3f8d'
-            '063ee23a9c98e728168affb8056cda201fb02ede2bd29dfe2b768ce834b35e7c'
-            '12299e53b5024084c73e604132db3a10b6e91763d90d484cabdd1985a17cf733'
-            'a7e82a1589406477898adee768d17c0270c8bcf341ae72be823095331c4e99c5')
+source=('https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-tools'
+        'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-tools.groff'
+        'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia@.service'
+        'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia_common'
+        'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-up'
+        'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-down'
+        'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-route-up'
+        ''https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-tools.install')
 install="${pkgname}.install"
 
 package() {
@@ -32,5 +26,5 @@ package() {
     install -Dm644 pia_common "${pkgdir}/etc/openvpn/pia/pia_common"
     install -Dm755 pia-up "${pkgdir}/etc/openvpn/pia/pia-up"
     install -Dm755 pia-up "${pkgdir}/etc/openvpn/pia/pia-down"
+    install -Dm755 pia-up "${pkgdir}/etc/openvpn/pia/pia-route-up"
 }
-

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -16,6 +16,14 @@ source=('https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-down'
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-route-up'
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-tools.install')
+md5sums=('23e2b79c6d4c1cc744595cd46ea345d0'
+         'b3fa2a6f12c6067bcb0024e54e25cf92'
+         'f74962b853215b88b54bad3dad9ba004'
+         '621f9228ba793b4307b354e92b8918c1'
+         'f25f00fe408f31e50d46d69a597c6ece'
+         'ac4fef9e231b1f7a9a009d7edf11db82'
+         '7077738433630cc80d758196b5bd2bde'
+         '24f69e9eea41a1247a974c7d5d3d9c30')
 install="${pkgname}.install"
 
 package() {

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=pia-tools
 pkgver=0.9.7.4
-pkgrel=4
+pkgrel=5
 pkgdesc='OpenVPN hook for privateinternetaccess.com'
 arch=('any')
 url='https://github.com/pschmitt/pia-tools'
@@ -17,13 +17,13 @@ source=('https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-route-up'
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia_common_single_user'
         'https://raw.githubusercontent.com/tempestnano/pia-tools/Single_user/pia-tools.install')
-md5sums=('0edb36ca688af899b9bd5fc3f1bd8beb'
+md5sums=('28070f9b6b9378d884cf46fb5b76f665'
          'b3fa2a6f12c6067bcb0024e54e25cf92'
          'f74962b853215b88b54bad3dad9ba004'
          '621f9228ba793b4307b354e92b8918c1'
          'f25f00fe408f31e50d46d69a597c6ece'
          '0ed5cf87b2853f9688c9df1dfe19b061'
-         '7077738433630cc80d758196b5bd2bde'
+         '3aa6dffb97bfb02a719c56b53de5658a'
          '3dfea239907a974507614357f6723856'
          '24f69e9eea41a1247a974c7d5d3d9c30')
 install="${pkgname}.install"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -38,4 +38,5 @@ package() {
     install -Dm755 pia-up "${pkgdir}/etc/openvpn/pia/pia-up"
     install -Dm755 pia-down "${pkgdir}/etc/openvpn/pia/pia-down"
     install -Dm755 pia-route-up "${pkgdir}/etc/openvpn/pia/pia-route-up"
+    install -Dm644 pia_common "${pkgdir}/etc/openvpn/pia/pia_common_single_user"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Philipp Schmitt (philipp<at>schmitt<dot>co)
 
 pkgname=pia-tools
-pkgver=0.9.7.3
+pkgver=0.9.7.4
 pkgrel=1
 pkgdesc='OpenVPN hook for privateinternetaccess.com'
 arch=('any')
@@ -38,5 +38,5 @@ package() {
     install -Dm755 pia-up "${pkgdir}/etc/openvpn/pia/pia-up"
     install -Dm755 pia-down "${pkgdir}/etc/openvpn/pia/pia-down"
     install -Dm755 pia-route-up "${pkgdir}/etc/openvpn/pia/pia-route-up"
-    install -Dm644 pia_common "${pkgdir}/etc/openvpn/pia/pia_common_single_user"
+    install -Dm644 pia_common_single_user "${pkgdir}/etc/openvpn/pia/pia_common_single_user"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -24,9 +24,8 @@ md5sums=('23e2b79c6d4c1cc744595cd46ea345d0'
          'f25f00fe408f31e50d46d69a597c6ece'
          '0ed5cf87b2853f9688c9df1dfe19b061'
          '7077738433630cc80d758196b5bd2bde'
-         '4de2a7e4b4dfc5d7da8f0d490e957dd3'
+         '3dfea239907a974507614357f6723856'
          '24f69e9eea41a1247a974c7d5d3d9c30')
-
 install="${pkgname}.install"
 
 package() {

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ mkdir -p /etc/openvpn/pia
 cat <<EOM > /etc/openvpn/pia/pia_common
 auth-user-pass passwd
 script-security 2
-up "/usr/bin/pia-tools -g"
-down "/usr/bin/pia-tools --restore-dns"
+up "/etc/openvpn/pia/pia-up"
+down "/etc/openvpn/pia/pia-down"
 route-noexec
 route-up /etc/openvpn/pia/pia_route_up.sh
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ PIA_CLIENT_ID_FILE="$PIA_CONFIG_DIR/clientid"
 TRANSMISSION_SETTINGS_FILE='/home/dl/.config/transmission-daemon/settings.json'
 PIA_OPEN_PORT_FILE="$PIA_CONFIG_DIR/open_port"
 VIRT_NET_DEV='tun0'
+VPN_USER='transmission'
 ```
 
 ## Read more

--- a/README.md
+++ b/README.md
@@ -73,6 +73,25 @@ EOM
 # Start interactive setup
 pia-tools --setup
 ```
+If instead you wish to only route traffic for your torrent client:
+```bash
+mkdir -p /etc/openvpn/pia
+
+# Feel free to edit the up/down parameters
+cat <<EOM > /etc/openvpn/pia/pia_common
+auth-user-pass passwd
+script-security 2
+up "/usr/bin/pia-tools -g"
+down "/usr/bin/pia-tools --restore-dns"
+route-noexec
+route-up /etc/openvpn/pia/pia_route_up.sh
+log /var/log/openvpn-Netherlands
+
+EOM
+
+# Start interactive setup
+pia-tools --setup
+```
 
 The setup will store your credentials in `/etc/openvpn/pia/passwd`, download the config files from PIA and append `/etc/openvpn/pia/pia_common` to all of them.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ up "/usr/bin/pia-tools -g"
 down "/usr/bin/pia-tools --restore-dns"
 route-noexec
 route-up /etc/openvpn/pia/pia_route_up.sh
-log /var/log/openvpn-Netherlands
 
 EOM
 

--- a/pia-down
+++ b/pia-down
@@ -1,5 +1,14 @@
 #!/usr/bin/sh
 
+test "$PIA_CONF" || PIA_CONF='/etc/pia-tools.conf'
+[[ -r "$PIA_CONF" ]] && . $PIA_CONF
+
+if [[ -n "$VPN_USER" ]]; then
+  ip route flush table $VPNUSER
+  ip route flush cache
+fi
+
+
 # Restore DNS settings
 (sleep 5 && pia-tools --restore-dns --check)&
 # Update conky

--- a/pia-down
+++ b/pia-down
@@ -4,7 +4,7 @@ test "$PIA_CONF" || PIA_CONF='/etc/pia-tools.conf'
 [[ -r "$PIA_CONF" ]] && . $PIA_CONF
 
 if [[ -n "$VPN_USER" ]]; then
-  ip route flush table $VPNUSER
+  ip route flush table $VPN_USER
   ip route flush cache
 fi
 

--- a/pia-route-up
+++ b/pia-route-up
@@ -1,0 +1,24 @@
+#!/usr/bin/sh
+
+# Source config file
+test "$PIA_CONF" || PIA_CONF='/etc/pia-tools.conf'
+[[ -r "$PIA_CONF" ]] && . $PIA_CONF
+
+if [[ -n "$VPN_USER" ]]; then
+  ip route add "$trusted_ip"/32 via $route_net_gateway table $VPNUSER
+  ip route add 0.0.0.0/1 via $route_vpn_gateway table $VPNUSER
+  ip route add 128.0.0.0/1 via $route_vpn_gateway table $VPNUSER
+  ip route add "$route_network_1"/32 via $route_vpn_gateway table $VPNUSER
+  ip route add $ifconfig_remote dev $dev scope link src $ifconfig_local table $VPNUSER
+
+
+
+
+  if [[ `ip rule list | grep -c 0x3` == 0 ]]; then
+    ip rule add from all fwmark 0x3 lookup $VPNUSER
+  fi
+
+  ip route append default via 127.0.0.1 dev lo table $VPNUSER
+  ip route flush cache
+fi
+exit 0

--- a/pia-route-up
+++ b/pia-route-up
@@ -1,24 +1,39 @@
 #!/usr/bin/sh
 
+
 # Source config file
 test "$PIA_CONF" || PIA_CONF='/etc/pia-tools.conf'
 [[ -r "$PIA_CONF" ]] && . $PIA_CONF
 
+if [[ -z "$TRANSMISSION_SETTINGS_FILE" ]]; then
+    TRANSMISSION_SETTINGS_FILE='/home/dl/.config/transmission-daemon/settings.json'
+fi
+check_transmission() {
+    systemctl is-active transmission > /dev/null 2>&1
+}
 if [[ -n "$VPN_USER" ]]; then
-  ip route add "$trusted_ip"/32 via $route_net_gateway table $VPNUSER
-  ip route add 0.0.0.0/1 via $route_vpn_gateway table $VPNUSER
-  ip route add 128.0.0.0/1 via $route_vpn_gateway table $VPNUSER
-  ip route add "$route_network_1"/32 via $route_vpn_gateway table $VPNUSER
-  ip route add $ifconfig_remote dev $dev scope link src $ifconfig_local table $VPNUSER
-
-
-
-
+  ip route add "$trusted_ip"/32 via $route_net_gateway table $VPN_USER
+  ip route add 0.0.0.0/1 via $route_vpn_gateway table $VPN_USER
+  ip route add 128.0.0.0/1 via $route_vpn_gateway table $VPN_USER
+  ip route add "$route_network_1"/32 via $route_vpn_gateway table $VPN_USER
+  ip route add $ifconfig_remote dev $dev scope link src $ifconfig_local table $VPN_USER
   if [[ `ip rule list | grep -c 0x3` == 0 ]]; then
-    ip rule add from all fwmark 0x3 lookup $VPNUSER
+    ip rule add from all fwmark 0x3 lookup $VPN_USER
   fi
-
-  ip route append default via 127.0.0.1 dev lo table $VPNUSER
+  ip route append default via 127.0.0.1 dev lo table $VPN_USER
   ip route flush cache
 fi
+
+if check_transmission; then
+    echo -n 'Stopping transmission... '
+    systemctl stop transmission
+    echo 'Done!'
+fi    
+sed -i "s/.*bind-address-ipv4.*/    \"bind-address-ipv4\": \"$ifconfig_local\",/g" $TRANSMISSION_SETTINGS_FILE
+if check_transmission; then
+    echo -n 'Starting transmission... '
+    systemctl start transmission
+    echo 'Done!'
+fi
+
 exit 0

--- a/pia-tools
+++ b/pia-tools
@@ -162,8 +162,19 @@ transmission_peer_port_update() {
         # get current listening port
         transmission_peer_port="$(transmission-remote -si | grep Listenport | grep -oE '[0-9]+')"
         if [[ "$PIA_OPEN_PORT_NEW" != "$transmission_peer_port" ]]; then
-            transmission-remote -p "$PIA_OPEN_PORT_NEW"
-            # systemctl restart transmission
+	    
+            TRANSUSER=$(cat $TRANSMISSION_SETTINGS_FILE | grep \"rpc-username\":)
+	    TRANSUSER=${TRANSUSER#*\"rpc-username\": }
+	    TRANSUSER=${TRANSUSER%*, }
+	    TRANSPASS=$(cat $TRANSMISSION_SETTINGS_FILE | grep \"rpc-password\":)
+	    TRANSPASS=${TRANSPASS#*\"rpc-password\": }
+	    TRANSPASS=${TRANSPASS%*, }
+	    if [[ -z $TRANSUSER ]]; then
+	        transmission-remote -p "$PIA_OPEN_PORT_NEW"
+            else
+		transmission-remote --auth $TRANSUSER:$TRANSPASS -p "$PIA_OPEN_PORT_NEW"
+	    fi 
+	# systemctl restart transmission
             echo 'Checking port...'
             # TODO The sleep timer may need to be adjusted
             sleep 3 && transmission-remote -pt

--- a/pia-tools
+++ b/pia-tools
@@ -210,11 +210,10 @@ request_port() {
         echo "VPN local IP: $local_vpn_ip"
     fi
     if [[ -n "$VPN_USER" ]]; then
-        PIA_OPEN_PORT_NEW="$(\
-        sudo -u $VPN_USER \
-        curl -Ld "user=$username&pass=$passwd&client_id=$client_id&local_ip=$local_vpn_ip" \
-        https://www.privateinternetaccess.com/vpninfo/port_forward_assignment \
-        | grep -oE "[0-9]+" 2>&1)"
+        PIA_OPEN_PORT_NEW="$(sudo -u $VPN_USER curl -Ld 'user=$username&pass=$passwd&client_id=$client_id&local_ip=$local_vpn_ip' https://www.privateinternetaccess.com/vpninfo/port_forward_assignment | grep -oE '[0-9]+' 2>&1)"
+    	echo "sudo -u $VPN_USER curl -Ld user=$username&pass=$passwd&client_id=$client_id&local_ip=$local_vpn_ip' https://www.privateinternetaccess.com/vpninfo/port_forward_assignment | grep -oE '[0-9]+' 2>&1)"
+	echo $PIA_OPEN_PORT_NEW
+
     else
     PIA_OPEN_PORT_NEW="$(\
         curl -Ld "user=$username&pass=$passwd&client_id=$client_id&local_ip=$local_vpn_ip" \

--- a/pia-tools
+++ b/pia-tools
@@ -210,15 +210,12 @@ request_port() {
         echo "VPN local IP: $local_vpn_ip"
     fi
     if [[ -n "$VPN_USER" ]]; then
-	PIA_CURL=$(sudo -u $VPN_USER curl -Ld "`user=$username&pass=$passwd&client_id=$client_id&local_ip=$local_vpn_ip`" https://www.privateinternetaccess.com/vpninfo/port_forward_assignment)
-	echo tacos
-	echo  "user=$username&pass=$passwd&client_id=$client_id&local_ip=$local_vpn_ip"
-	echo $PIA_CURL
-	PIA_OPEN_PORT_NEW= echo $PIA_CURL | grep -oE "[0-9]+" 2>&1
-	echo $PIA_OPEN_PORT_NEW
-
+	PIA_CURL_DATA="user=$username&pass=$passwd&client_id=$client_id&local_ip=$local_vpn_ip"
+	PIA_PORT_URL='https://www.privateinternetaccess.com/vpninfo/port_forward_assignment'
+	PIA_CURL=$(sudo -u transmission curl -Ld "$PIA_CURL_DATA" "$PIA_PORT_URL")
+	PIA_OPEN_PORT_NEW=$(echo $PIA_CURL | grep -oE "[0-9]+" 2>&1)
     else
-    PIA_OPEN_PORT_NEW="$(\
+        PIA_OPEN_PORT_NEW="$(\
         curl -Ld "user=$username&pass=$passwd&client_id=$client_id&local_ip=$local_vpn_ip" \
         https://www.privateinternetaccess.com/vpninfo/port_forward_assignment \
         | grep -oE "[0-9]+" 2>&1)"
@@ -361,21 +358,14 @@ iptables_mark(){
     # only list the interface used to reach a specific host/IP. We only want the part between dev and src (use grep for that)
     DEFAULT_INTERFACE=$(ip route get "$host_ip" | grep -Po '(?<=(dev )).*(?= src)')
     #Get ip address of default interface in A.B.C.D/n format
-	echo "ip addr show dev $DEFAULT_INTERFACE | sed -nr 's/.*inet ([^ ]+).*/\1/p'"
     DEFAULT_IP=$(ip addr show dev $DEFAULT_INTERFACE | sed -nr 's/.*inet ([^ ]+).*/\1/p')
-
-    echo $DEFAULT_IP >> /tmp/FULL_IP
     iptables -t mangle -A OUTPUT ! --dest $DEFAULT_IP  -m owner --uid-owner $VPN_USER -j MARK --set-mark 0x3 -m comment --comment $VPN_USER
-	echo "iptables -t mangle -A OUTPUT ! --dest $DEFAULT_IP  -m owner --uid-owner $VPN_USER -j MARK --set-mark 0x3 -m comment --comment $VPN_USER"
-# let $VPNUSER access lo and $INTERFACE
+    # let $VPNUSER access lo and $INTERFACE
     iptables -A OUTPUT -o lo -m owner --uid-owner $VPN_USER -j ACCEPT -m comment --comment $VPN_USER
     iptables -A OUTPUT -o $VIRT_NET_DEV -m owner --uid-owner $VPN_USER -j ACCEPT -m comment --comment $VPN_USER
     # all packets on $VIRT_NET_DEV needs to be masqueraded
     iptables -t nat -A POSTROUTING -o $VIRT_NET_DEV -j MASQUERADE -m comment --comment $VPN_USER
 
-    echo "iptables -A OUTPUT -o lo -m owner --uid-owner $VPN_USER -j ACCEPT -m comment --comment $VPN_USER"
-    echo "iptables -A OUTPUT -o $VIRT_NET_DEV -m owner --uid-owner $VPN_USER -j ACCEPT -m comment --comment $VPN_USER"
-	echo "iptables -t nat -A POSTROUTING -o $VIRT_NET_DEV -j MASQUERADE -m comment --comment $VPN_USER"
 
 }
 

--- a/pia-tools
+++ b/pia-tools
@@ -349,27 +349,35 @@ iptables_mark(){
     if [[ -z $VPN_USER ]] ; then
             VPN_USER=transmission
     fi
-    iptables-save | grep -v "$VPN_USER VPN" | iptables-restore
+    iptables-save | grep -v "$VPN_USER" | iptables-restore
     iptables-save | grep -v "$VIRT_NET_DEV" | iptables-restore
 
     # host we want to "reach"
-    host=$trusted_ip
+    host=google.com
     # get the ip of that host (works with dns and /etc/hosts. In case we get multiple ipaddresses, we just want one of them
     host_ip=$(getent ahosts "$host" | head -1 | awk '{print $1}')
     # only list the interface used to reach a specific host/IP. We only want the part between dev and src (use grep for that)
     DEFAULT_INTERFACE=$(ip route get "$host_ip" | grep -Po '(?<=(dev )).*(?= src)')
     #Get ip address of default interface in A.B.C.D/n format
-    DEFAULT_IP=$(ip addr show dev $interface | sed -nr 's/.*inet ([^ ]+).*/\1/p')
+	echo "ip addr show dev $DEFAULT_INTERFACE | sed -nr 's/.*inet ([^ ]+).*/\1/p'"
+    DEFAULT_IP=$(ip addr show dev $DEFAULT_INTERFACE | sed -nr 's/.*inet ([^ ]+).*/\1/p')
 
     echo $DEFAULT_IP >> /tmp/FULL_IP
-    iptables -t mangle -A OUTPUT ! --dest $DEFAULT_IP  -m owner --uid-owner $VPN_USER -j MARK --set-mark 0x3 -m comment --comment "$VPN_USER VPN"
-    echo "iptables -t mangle -A OUTPUT ! --dest $DEFAULT_IP  -m owner --uid-owner $VPN_USER -j MARK --set-mark 0x3 -m comment --comment $VPN_USER VPN"    
+    iptables -t mangle -A OUTPUT ! --dest $DEFAULT_IP  -m owner --uid-owner $VPN_USER -j MARK --set-mark 0x3 -m comment --comment $VPN_USER
+	echo "iptables -t mangle -A OUTPUT ! --dest $DEFAULT_IP  -m owner --uid-owner $VPN_USER -j MARK --set-mark 0x3 -m comment --comment $VPN_USER"
 # let $VPNUSER access lo and $INTERFACE
-    iptables -A OUTPUT -o lo -m owner --uid-owner $VPN_USER -j ACCEPT -m comment --comment "$VPN_USER VPN"
-    iptables -A OUTPUT -o $INTERFACE_VPN -m owner --uid-owner $VPN_USER -j ACCEPT -m comment --comment "$VPN_USER VPN"
-    # all packets on $INTERFACE_VPN needs to be masqueraded
-    iptables -t nat -A POSTROUTING -o $INTERFACE_VPN -j MASQUERADE -m comment --comment "$VPN_USER VPN"
+    iptables -A OUTPUT -o lo -m owner --uid-owner $VPN_USER -j ACCEPT -m comment --comment $VPN_USER
+    iptables -A OUTPUT -o $VIRT_NET_DEV -m owner --uid-owner $VPN_USER -j ACCEPT -m comment --comment $VPN_USER
+    # all packets on $VIRT_NET_DEV needs to be masqueraded
+    iptables -t nat -A POSTROUTING -o $VIRT_NET_DEV -j MASQUERADE -m comment --comment $VPN_USER
+
+    echo "iptables -A OUTPUT -o lo -m owner --uid-owner $VPN_USER -j ACCEPT -m comment --comment $VPN_USER"
+    echo "iptables -A OUTPUT -o $VIRT_NET_DEV -m owner --uid-owner $VPN_USER -j ACCEPT -m comment --comment $VPN_USER"
+	echo "iptables -t nat -A POSTROUTING -o $VIRT_NET_DEV -j MASQUERADE -m comment --comment $VPN_USER"
+
 }
+
+
 
 
 # If no option -> refresh

--- a/pia-tools
+++ b/pia-tools
@@ -197,10 +197,18 @@ request_port() {
         echo "Client ID: $client_id"
         echo "VPN local IP: $local_vpn_ip"
     fi
+    if [[ -n "$VPN_USER" ]]; then
+        PIA_OPEN_PORT_NEW="$(\
+        sudo -u transmission \
+        curl -Ld "user=$username&pass=$passwd&client_id=$client_id&local_ip=$local_vpn_ip" \
+        https://www.privateinternetaccess.com/vpninfo/port_forward_assignment \
+        | grep -oE "[0-9]+" 2>&1)"
+    else
     PIA_OPEN_PORT_NEW="$(\
         curl -Ld "user=$username&pass=$passwd&client_id=$client_id&local_ip=$local_vpn_ip" \
         https://www.privateinternetaccess.com/vpninfo/port_forward_assignment \
         | grep -oE "[0-9]+" 2>&1)"
+    fi
     if test "$PIA_OPEN_PORT_NEW"; then
         echo "$PIA_OPEN_PORT_NEW" > "$PIA_OPEN_PORT_FILE"
         echo "Done! Port: $PIA_OPEN_PORT_NEW"
@@ -308,6 +316,27 @@ restore_dns() {
     fi
     mv -f /etc/resolv.conf.orig /etc/resolv.conf
 }
+rt_tables_add(){
+    if [ -z "`cat /etc/iproute2/rt_tables | grep '^51'`" ] ; then
+	    echo "51	$VPN_USER" >> /etc/iproute2/rt_tables
+	fi
+	    $echo "0" > /proc/sys/net/ipv4/conf/all/rp_filter 
+	    $echo "0" > /proc/sys/net/ipv4/conf/default/rp_filter 
+	    $echo "1" > /proc/sys/net/ipv4/ip_forward 
+	    $echo "1" > /proc/sys/net/ipv6/conf/default/forwarding
+	    $echo "1" > /proc/sys/net/ipv6/conf/all/forwarding
+}
+iptables_mark(){
+    iptables-save | grep -v "$VPNUSER VPN" | iptables-restore
+    iptables-save | grep -v "$dev" | iptables-restore
+    iptables -t mangle -A OUTPUT ! --dest $FULL_IP  -m owner --uid-owner $VPNUSER -j MARK --set-mark 0x3 -m comment --comment "$VPN_USER VPN"
+    # let $VPNUSER access lo and $INTERFACE
+    iptables -A OUTPUT -o lo -m owner --uid-owner $VPNUSER -j ACCEPT -m comment --comment "$VPN_USER VPN"
+    iptables -A OUTPUT -o $INTERFACE_VPN -m owner --uid-owner $VPNUSER -j ACCEPT -m comment --comment "$VPN_USER VPN"
+    # all packets on $INTERFACE_VPN needs to be masqueraded
+    iptables -t nat -A POSTROUTING -o $INTERFACE_VPN -j MASQUERADE -m comment --comment "$VPN_USER VPN"
+}
+
 
 # If no option -> refresh
 if [[ $# -eq 0 ]]; then
@@ -339,6 +368,11 @@ while true; do
         -d|--disallow)
             test "$action_fw" && exit 1
             action_fw=disallow
+            shift
+            ;;
+        -S|--SingleUser)
+            test -z "$VPN_USER" && exit 1
+            action_single_user=$VPN_USER
             shift
             ;;
         -p|--port)
@@ -416,7 +450,7 @@ test "$action_info" && { info; exit $?; }
 test "$action_setup" && { setup; exit $?; }
 test "$action_update" && update_config
 test "$action_check" && check_ovpn
-
+test "$action_single_user" && { rt_tables_add ; iptables_mark; exit $?; }
 case "$action_dns" in
     google) google_dns ;;
     restore) restore_dns ;;

--- a/pia-tools
+++ b/pia-tools
@@ -268,8 +268,12 @@ update_config() {
             mv "$ovpn" "$ovpn_spaceless"
         fi
         # Append up/down scripts to every ovpn file
-        cat "$PIA_COMMON_CONFIG"  | sed -e "s/passwd/$PIA_PASSWD_FILE/" >>  "$ovpn_spaceless"
+        cat "$PIA_COMMON_CONFIG" >>  "$ovpn_spaceless"
     done
+    if [[ $PIA_PASSWD_FILE != "passwd" ]]; then
+        ln -sfn $PIA_PASSWD_FILE $PIA_CONFIG_DIR/passwd
+    fi
+
     IFS=$ifs_bak
 
     # Extract server addresses and resolve hosts

--- a/pia-tools
+++ b/pia-tools
@@ -58,6 +58,7 @@ usage() {
     echo "-c: Ensure OpenVPN is running. If not stop transmission"
     echo "-h: Display this message"
     echo "-v: Verbose output"
+    echo "-S: Only allow a single user's traffic"
 }
 
 # Checks if executed as root. If not reinvoke self with sudo
@@ -210,7 +211,7 @@ request_port() {
     fi
     if [[ -n "$VPN_USER" ]]; then
         PIA_OPEN_PORT_NEW="$(\
-        sudo -u transmission \
+        sudo -u $VPN_USER \
         curl -Ld "user=$username&pass=$passwd&client_id=$client_id&local_ip=$local_vpn_ip" \
         https://www.privateinternetaccess.com/vpninfo/port_forward_assignment \
         | grep -oE "[0-9]+" 2>&1)"
@@ -332,22 +333,40 @@ restore_dns() {
     mv -f /etc/resolv.conf.orig /etc/resolv.conf
 }
 rt_tables_add(){
+	if [[ -z $VPN_USER ]] ; then
+		VPN_USER=transmission
+	fi
     if [ -z "`cat /etc/iproute2/rt_tables | grep '^51'`" ] ; then
 	    echo "51	$VPN_USER" >> /etc/iproute2/rt_tables
 	fi
-	    $echo "0" > /proc/sys/net/ipv4/conf/all/rp_filter 
-	    $echo "0" > /proc/sys/net/ipv4/conf/default/rp_filter 
-	    $echo "1" > /proc/sys/net/ipv4/ip_forward 
-	    $echo "1" > /proc/sys/net/ipv6/conf/default/forwarding
-	    $echo "1" > /proc/sys/net/ipv6/conf/all/forwarding
+            sysctl -w net.ipv4.conf.all.rp_filter=0
+            sysctl -w net.ipv4.conf.default.rp_filter=0
+            sysctl -w net.ipv4.ip_forward=1
+            sysctl -w net.ipv6.conf.default.forwarding=1
+            sysctl -w net.ipv6.conf.all.forwarding=1
 }
 iptables_mark(){
-    iptables-save | grep -v "$VPNUSER VPN" | iptables-restore
-    iptables-save | grep -v "$dev" | iptables-restore
-    iptables -t mangle -A OUTPUT ! --dest $FULL_IP  -m owner --uid-owner $VPNUSER -j MARK --set-mark 0x3 -m comment --comment "$VPN_USER VPN"
-    # let $VPNUSER access lo and $INTERFACE
-    iptables -A OUTPUT -o lo -m owner --uid-owner $VPNUSER -j ACCEPT -m comment --comment "$VPN_USER VPN"
-    iptables -A OUTPUT -o $INTERFACE_VPN -m owner --uid-owner $VPNUSER -j ACCEPT -m comment --comment "$VPN_USER VPN"
+    if [[ -z $VPN_USER ]] ; then
+            VPN_USER=transmission
+    fi
+    iptables-save | grep -v "$VPN_USER VPN" | iptables-restore
+    iptables-save | grep -v "$VIRT_NET_DEV" | iptables-restore
+
+    # host we want to "reach"
+    host=$trusted_ip
+    # get the ip of that host (works with dns and /etc/hosts. In case we get multiple ipaddresses, we just want one of them
+    host_ip=$(getent ahosts "$host" | head -1 | awk '{print $1}')
+    # only list the interface used to reach a specific host/IP. We only want the part between dev and src (use grep for that)
+    DEFAULT_INTERFACE=$(ip route get "$host_ip" | grep -Po '(?<=(dev )).*(?= src)')
+    #Get ip address of default interface in A.B.C.D/n format
+    DEFAULT_IP=$(ip addr show dev $interface | sed -nr 's/.*inet ([^ ]+).*/\1/p')
+
+    echo $DEFAULT_IP >> /tmp/FULL_IP
+    iptables -t mangle -A OUTPUT ! --dest $DEFAULT_IP  -m owner --uid-owner $VPN_USER -j MARK --set-mark 0x3 -m comment --comment "$VPN_USER VPN"
+    echo "iptables -t mangle -A OUTPUT ! --dest $DEFAULT_IP  -m owner --uid-owner $VPN_USER -j MARK --set-mark 0x3 -m comment --comment $VPN_USER VPN"    
+# let $VPNUSER access lo and $INTERFACE
+    iptables -A OUTPUT -o lo -m owner --uid-owner $VPN_USER -j ACCEPT -m comment --comment "$VPN_USER VPN"
+    iptables -A OUTPUT -o $INTERFACE_VPN -m owner --uid-owner $VPN_USER -j ACCEPT -m comment --comment "$VPN_USER VPN"
     # all packets on $INTERFACE_VPN needs to be masqueraded
     iptables -t nat -A POSTROUTING -o $INTERFACE_VPN -j MASQUERADE -m comment --comment "$VPN_USER VPN"
 }
@@ -362,7 +381,7 @@ fi
 # Every function except help needs root permissions
 check_root "$*"
 
-ARGS=$(getopt -o "adprfguscihv" \
+ARGS=$(getopt -o "adprfguscihvS" \
               -l "allow,disallow,\
                   port,refresh,pia-dns,google-dns,restore-dns,\
                   restore,force,\

--- a/pia-tools
+++ b/pia-tools
@@ -210,8 +210,11 @@ request_port() {
         echo "VPN local IP: $local_vpn_ip"
     fi
     if [[ -n "$VPN_USER" ]]; then
-        PIA_OPEN_PORT_NEW="$(sudo -u $VPN_USER curl -Ld 'user=$username&pass=$passwd&client_id=$client_id&local_ip=$local_vpn_ip' https://www.privateinternetaccess.com/vpninfo/port_forward_assignment | grep -oE '[0-9]+' 2>&1)"
-    	echo "sudo -u $VPN_USER curl -Ld user=$username&pass=$passwd&client_id=$client_id&local_ip=$local_vpn_ip' https://www.privateinternetaccess.com/vpninfo/port_forward_assignment | grep -oE '[0-9]+' 2>&1)"
+	PIA_CURL=$(sudo -u $VPN_USER curl -Ld "`user=$username&pass=$passwd&client_id=$client_id&local_ip=$local_vpn_ip`" https://www.privateinternetaccess.com/vpninfo/port_forward_assignment)
+	echo tacos
+	echo  "user=$username&pass=$passwd&client_id=$client_id&local_ip=$local_vpn_ip"
+	echo $PIA_CURL
+	PIA_OPEN_PORT_NEW= echo $PIA_CURL | grep -oE "[0-9]+" 2>&1
 	echo $PIA_OPEN_PORT_NEW
 
     else

--- a/pia-tools
+++ b/pia-tools
@@ -268,7 +268,7 @@ update_config() {
             mv "$ovpn" "$ovpn_spaceless"
         fi
         # Append up/down scripts to every ovpn file
-        cat "$PIA_COMMON_CONFIG"  >> "$ovpn_spaceless"
+        cat "$PIA_COMMON_CONFIG"  | sed -e "s/passwd/$PIA_PASSWD_FILE/" >>  "$ovpn_spaceless"
     done
     IFS=$ifs_bak
 

--- a/pia-up
+++ b/pia-up
@@ -2,6 +2,8 @@
 
 # Change DNS settings right away
 pia-tools --pia-dns
+# Process single vpn user if $VPN_USER is defined
+pia-tools -S
 # Port forward request will fail if asked too early
 (sleep 5 && pia-tools -r)&
 # Update conky

--- a/pia-up
+++ b/pia-up
@@ -5,7 +5,7 @@ pia-tools --pia-dns
 # Process single vpn user if $VPN_USER is defined
 pia-tools -S
 # Port forward request will fail if asked too early
-(sleep 5 && pia-tools -r)&
+(sleep 10 && pia-tools -r)&
 # Update conky
 (sleep 5 && killall -SIGUSR1 conky)&
 

--- a/pia-up.save
+++ b/pia-up.save
@@ -1,0 +1,12 @@
+#!/usr/bin/sh
+
+# Change DNS settings right away
+pia-tools --pia-dns
+# Process single vpn user if $VPN_USER is defined
+pia-tools -S $trusted_ip
+# Port forward request will fail if asked too early
+(sleep 5 && pia-tools -r)&
+# Update conky
+(sleep 5 && killall -SIGUSR1 conky)&
+
+exit 0

--- a/pia_common
+++ b/pia_common
@@ -2,3 +2,5 @@ auth-user-pass passwd
 script-security 2 
 up "/etc/openvpn/pia/pia-up"
 down "/etc/openvpn/pia/pia-down"
+route-noexec
+route-up /etc/openvpn/pia/pia_route_up.sh

--- a/pia_common
+++ b/pia_common
@@ -2,5 +2,3 @@ auth-user-pass passwd
 script-security 2 
 up "/etc/openvpn/pia/pia-up"
 down "/etc/openvpn/pia/pia-down"
-route-noexec
-route-up /etc/openvpn/pia/pia_route_up.sh

--- a/pia_common_single_user
+++ b/pia_common_single_user
@@ -3,4 +3,4 @@ script-security 2
 up "/etc/openvpn/pia/pia-up"
 down "/etc/openvpn/pia/pia-down"
 route-noexec
-route-up /etc/openvpn/pia/pia_route_up.sh
+route-up /etc/openvpn/pia/pia_route_up

--- a/pia_common_single_user
+++ b/pia_common_single_user
@@ -3,4 +3,4 @@ script-security 2
 up "/etc/openvpn/pia/pia-up"
 down "/etc/openvpn/pia/pia-down"
 route-noexec
-route-up /etc/openvpn/pia/pia-route-up
+route-up "/etc/openvpn/pia/pia-route-up"

--- a/pia_common_single_user
+++ b/pia_common_single_user
@@ -3,4 +3,4 @@ script-security 2
 up "/etc/openvpn/pia/pia-up"
 down "/etc/openvpn/pia/pia-down"
 route-noexec
-route-up /etc/openvpn/pia/pia_route_up
+route-up /etc/openvpn/pia/pia-route-up

--- a/pia_common_single_user
+++ b/pia_common_single_user
@@ -1,0 +1,6 @@
+auth-user-pass passwd
+script-security 2 
+up "/etc/openvpn/pia/pia-up"
+down "/etc/openvpn/pia/pia-down"
+route-noexec
+route-up /etc/openvpn/pia/pia_route_up.sh


### PR DESCRIPTION
I have added the option of tunneling only the traffic from a single user, with transmission being the obvious choice. I am sure this will require some revision, as there must be a cleaner way of doing this that would be clearly visible to a more experienced coder.

Adding VPN_USER=transmission to the conf file will enable this feature. pia_common must also be modified as indicated in the README for this to work properly. An alternate pia_common (pia_common_single_user) file has been included, but it must be manually copied over pia_common before the pia_tools -s command is executed.

This modification works by using a separate routing table and selective packet marking.