### PR TITLE
Revert to Old Behaviour of Adding Rules for All Network Devices by Default

### DIFF
--- a/pia-tools
+++ b/pia-tools
@@ -40,7 +40,7 @@ if [[ -z "$PIA_OPEN_PORT_FILE" ]]; then
 fi
 PIA_OPEN_PORT="$(cat $PIA_OPEN_PORT_FILE 2>/dev/null)"
 if [[ -z "$NETWORK_DEVICES" ]]; then
-    NETWORK_DEVICES=$(ip route get "$(host privateinternetaccess.com | awk '/has address/ { print $4 }')" | awk '/dev/ { print $5 }')
+    NETWORK_DEVICES=$(ip link show | awk -v ORS="" -F ":" '/^[0-9]/ && !/lo/ && !/tun/ {print $2}' | sed 's/^ //')
 fi
 if [[ -z "$VIRT_NET_DEV" ]]; then
     VIRT_NET_DEV='tun0'

--- a/pia-tools
+++ b/pia-tools
@@ -321,7 +321,7 @@ check_root "$*"
 ARGS=$(getopt -o "adprfguscihv" \
               -l "allow,disallow,\
                   port,refresh,pia-dns,google-dns,restore-dns,\
-                  restore,force,\
+                  restore,force,check,\
                   update,setup,info,help,verbose" \
               -n "$0" -- "$@")
 


### PR DESCRIPTION
This pull request addresses issue #10 and changes the default behaviour to how it used to be without using ifconfig. I think it's preferable to add all network devices instead of only the one that is currently in use (since that can quickly change).

Alternatively, if you want to keep the new behaviour, the man page should be updated to reflect this. You might also consider using ip link and checking for "state UP".