### PR TITLE
Use User's $HOME for Fallback Transmission Config File Location

### DIFF
--- a/pia-tools
+++ b/pia-tools
@@ -40,7 +40,7 @@ if [[ -z "$PIA_OPEN_PORT_FILE" ]]; then
 fi
 PIA_OPEN_PORT="$(cat $PIA_OPEN_PORT_FILE 2>/dev/null)"
 if [[ -z "$NETWORK_DEVICES" ]]; then
-    NETWORK_DEVICES=$(ip route get "$(host privateinternetaccess.com | awk '/has address/ { print $4 }')" | awk '/dev/ { print $5 }')
+    NETWORK_DEVICES=$(ip link show | awk -v ORS="" -F ":" '/^[0-9]/ && !/lo/ && !/tun/ {print $2}' | sed 's/^ //')
 fi
 if [[ -z "$VIRT_NET_DEV" ]]; then
     VIRT_NET_DEV='tun0'

--- a/pia-tools
+++ b/pia-tools
@@ -321,7 +321,7 @@ check_root "$*"
 ARGS=$(getopt -o "adprfguscihv" \
               -l "allow,disallow,\
                   port,refresh,pia-dns,google-dns,restore-dns,\
-                  restore,force,\
+                  restore,force,check,\
                   update,setup,info,help,verbose" \
               -n "$0" -- "$@")
 

--- a/pia-tools
+++ b/pia-tools
@@ -33,7 +33,8 @@ if [[ -z "$PIA_CLIENT_ID_FILE" ]]; then
     PIA_CLIENT_ID_FILE="$PIA_CONFIG_DIR/clientid"
 fi
 if [[ -z "$TRANSMISSION_SETTINGS_FILE" ]]; then
-    TRANSMISSION_SETTINGS_FILE="$HOME/.config/transmission-daemon/settings.json"
+    current_user_home=$(eval echo ~$(logname))
+    TRANSMISSION_SETTINGS_FILE="$current_user_home/.config/transmission-daemon/settings.json"
 fi
 if [[ -z "$PIA_OPEN_PORT_FILE" ]]; then
     PIA_OPEN_PORT_FILE="$PIA_CONFIG_DIR/open_port"

--- a/pia-tools
+++ b/pia-tools
@@ -33,7 +33,7 @@ if [[ -z "$PIA_CLIENT_ID_FILE" ]]; then
     PIA_CLIENT_ID_FILE="$PIA_CONFIG_DIR/clientid"
 fi
 if [[ -z "$TRANSMISSION_SETTINGS_FILE" ]]; then
-    TRANSMISSION_SETTINGS_FILE='/home/dl/.config/transmission-daemon/settings.json'
+    TRANSMISSION_SETTINGS_FILE="$HOME/.config/transmission-daemon/settings.json"
 fi
 if [[ -z "$PIA_OPEN_PORT_FILE" ]]; then
     PIA_OPEN_PORT_FILE="$PIA_CONFIG_DIR/open_port"

--- a/pia-tools.groff
+++ b/pia-tools.groff
@@ -81,7 +81,7 @@ File holding your PIA credentials (default: $PIA_CONFIG_DIR/passwd)
 .IP \fBPIA_CLIENT_ID_FILE\fR
 File where your client-ID is stored (default: $PIA_CONFIG_DIR/clientid)
 .IP \fBTRANSMISSION_SETTINGS_FILE\fR
-Path to transmission config (default: /home/dl/.config/transmission-daemon/settings.json)
+Path to transmission config (default: (current user's) $HOME/.config/transmission-daemon/settings.json)
 .IP \fBPIA_OPEN_PORT_FILE\fR
 Path to the file where the currently open (forwarded) port is stored (default: $PIA_CONFIG_DIR/open_port)
 .IP \fBVIRT_NET_DEV\fR


### PR DESCRIPTION
This ensures the the fallback path is the default location of the transmission settings file.