### PR TITLE
Clean up PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,33 +3,17 @@
 pkgname=pia-tools-orig
 pkgver=0.9.8.0
 pkgrel=1
-pkgdesc='OpenVPN hook for privateinternetaccess.com'
-arch=('any')
-url='https://github.com/pschmitt/pia-tools'
-license=('GPL3')
-depends=('transmission-cli' 'bind-tools' 'openvpn' 'systemd' 'sudo' 'wget' 'ufw' 'unzip' 'sed')
-source=('https://raw.github.com/pschmitt/pia-tools/master/pia-tools'
-        'https://raw.github.com/pschmitt/pia-tools/master/pia-tools.groff'
-        'https://raw.github.com/pschmitt/pia-tools/master/pia@.service'
-        'https://raw.github.com/pschmitt/pia-tools/master/pia_common'
-        'https://raw.github.com/pschmitt/pia-tools/master/pia-up'
-        'https://raw.github.com/pschmitt/pia-tools/master/pia-down'
-        'https://raw.github.com/pschmitt/pia-tools/master/pia-tools.install'
-        'https://raw.github.com/pschmitt/pia-tools/master/pia-tools-update.service'
-        'https://raw.github.com/pschmitt/pia-tools/master/pia-tools-update.timer')
-sha256sums=('cbf5002c50e084b847375cb78df0fb1b694e830657711d58b48ef8b0bee09aec'
-            '22a34cb38e02ee1ed32e5697bc507df074629cbf5f1f7290a72e2c947cf611eb'
-            '118d961db36fb243e059543215a818d1546ec94e8d52b24c75b7de6fe64ba749'
-            'b571a8edbd9cb2a9ad63fadf360f64d4f80e291295f6c851b3a716c291ba3f8d'
-            '063ee23a9c98e728168affb8056cda201fb02ede2bd29dfe2b768ce834b35e7c'
-            '12299e53b5024084c73e604132db3a10b6e91763d90d484cabdd1985a17cf733'
-            'a7e82a1589406477898adee768d17c0270c8bcf341ae72be823095331c4e99c5'
-            '9c85077075dc9192109abb9736f5905721574ce3b902f6d709afc6e262c8ed29'
-            'dee96c9e2a3f8d447d1d8aafbb1fc10fcd124e89239f1078311d5ce2c963359f')
-install="pia-tools.install"
+pkgdesc="OpenVPN hook for privateinternetaccess.com"
+arch=("any")
+url="https://github.com/pschmitt/pia-tools-orig"
+license=("GPL3")
+depends=("transmission-cli" "bind-tools" "openvpn" "systemd" "sudo" "wget" "ufw" "unzip" "sed")
+source=("pia-tools-$pkgver.tar.gz::https://github.com/pschmitt/pia-tools/archive/$pkgver.tar.gz")
+sha256sums=('39f937480bcd88ef84a69d3855332ec4d51fd483d22f73782d9e3d36af3cad59')
+install="${pkgname}.install"
 
 package() {
-    cd "${srcdir}"
+    cd "$pkgname-$pkgver"
     install -Dm755 pia-tools "${pkgdir}/usr/bin/pia-tools"
     install -Dm644 pia-tools.groff "${pkgdir}/usr/share/man/man1/pia-tools.1"
     install -Dm644 pia@.service "${pkgdir}/usr/lib/systemd/system/pia@.service"


### PR DESCRIPTION
Rather than linking to raw files, this will link to the latest stable tarball of the source.

Also includes some style changes, preferring a programatic approach to dealing with the package's name and version where possible.

Freenode/#archlinux users Earnestly, polyzen, and [alad](https://wiki.archlinux.org/index.php/User:alad) helped with this.


When I wanted to put pia-tools back on the AUR, those users told me I had to make these changes in the PKGBUILD before anything else, so I think these are worthwhile fixes.

And @pschmitt, I'm glad to see you're back!