### PR TITLE
Fix inactivity timeout re-login auth failure

### DIFF
--- a/pia_common
+++ b/pia_common
@@ -1,4 +1,5 @@
 auth-user-pass passwd
-script-security 2 
+script-security 2
+pull-filter ignore "auth-token"
 up "/etc/openvpn/pia/pia-up"
 down "/etc/openvpn/pia/pia-down"


### PR DESCRIPTION
After a certain amount of time of inactivity (about 5 min), OpenVPN restarts (it receives a SIGUSR1 signal) but can't login to pia afterwards.
According to [this thread](https://www.privateinternetaccess.com/forum/discussion/24089/inactivity-timeout-ping-restart#latest), the pull request fixes the issue.

I tested on my local machine that only has pia-tools as OpenVPN helper installed and it solves my issue.